### PR TITLE
Superfluous line is removed from substitute test

### DIFF
--- a/test/automated/substitute.rb
+++ b/test/automated/substitute.rb
@@ -6,7 +6,6 @@ context "Substitute" do
 
     context "UUID" do
       uuid_val = uuid.get
-      is_uuid = Identifier::UUID.uuid?(uuid_val)
 
       test "Is a Zero UUID" do
         assert(uuid_val == Identifier::UUID.zero)


### PR DESCRIPTION
I noticed what appears to be a superfluous line from the substitute test file. Removing it had no effect on test execution.